### PR TITLE
feat: Implement txn execution, simulation, and signing; Get programable txn construction working

### DIFF
--- a/lib/src/androidJvmMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.androidjvm.kt
+++ b/lib/src/androidJvmMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.androidjvm.kt
@@ -79,3 +79,16 @@ actual fun importFromMnemonic(mnemonic: List<String>): KeyPair {
   val seed = MnemonicCode.toSeed(mnemonic, "")
   return generateKeyPair(seed, SignatureScheme.ED25519)
 }
+
+actual fun sign(message: ByteArray, privateKey: PrivateKey): ByteArray {
+  when (privateKey) {
+    is Ed25519PrivateKey -> {
+      val signer = org.bouncycastle.crypto.signers.Ed25519Signer()
+      val privateKeyParameters = Ed25519PrivateKeyParameters(privateKey.data, 0)
+      signer.init(true, privateKeyParameters)
+      signer.update(message, 0, message.size)
+      return signer.generateSignature()
+    }
+    else -> throw SignatureSchemeNotSupportedException()
+  }
+}

--- a/lib/src/appleMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.apple.kt
+++ b/lib/src/appleMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.apple.kt
@@ -51,3 +51,10 @@ actual fun importFromMnemonic(mnemonic: String): KeyPair {
 actual fun importFromMnemonic(mnemonic: List<String>): KeyPair {
   TODO("Not yet implemented")
 }
+
+actual fun sign(
+  message: ByteArray,
+  privateKey: PrivateKey,
+): ByteArray {
+  TODO("Not yet implemented")
+}

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/account/Account.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/account/Account.kt
@@ -53,6 +53,8 @@ abstract class Account {
 
   abstract val scheme: SignatureScheme
 
+  abstract fun sign(message: ByteArray): ByteArray
+
   companion object {
 
     /**

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/account/Ed25519Account.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/account/Ed25519Account.kt
@@ -55,6 +55,10 @@ class Ed25519Account(private val privateKey: Ed25519PrivateKey) : Account() {
   override val scheme: SignatureScheme
     get() = SignatureScheme.ED25519
 
+  override fun sign(message: ByteArray): ByteArray {
+    return privateKey.sign(message)
+  }
+
   constructor(privateKey: Ed25519PrivateKey, mnemonic: String) : this(privateKey) {
     this.mnemonic = mnemonic
   }

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/api/Transaction.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/api/Transaction.kt
@@ -15,12 +15,20 @@
  */
 package xyz.mcxross.ksui.api
 
+import xyz.mcxross.ksui.account.Account
+import xyz.mcxross.ksui.generated.DryRunTransactionBlock
+import xyz.mcxross.ksui.generated.ExecuteTransactionBlock
+import xyz.mcxross.ksui.internal.dryRunTransactionBlock
+import xyz.mcxross.ksui.internal.executeTransactionBlock
 import xyz.mcxross.ksui.internal.getTotalTransactionBlocks
+import xyz.mcxross.ksui.internal.signAndSubmitTransaction
+import xyz.mcxross.ksui.model.ExecuteTransactionBlockResponseOptions
 import xyz.mcxross.ksui.model.Option
 import xyz.mcxross.ksui.model.SuiConfig
+import xyz.mcxross.ksui.model.TransactionBlockResponseOptions
 import xyz.mcxross.ksui.model.TransactionBlocks
-import xyz.mcxross.ksui.model.TransactionBlocksOptions
 import xyz.mcxross.ksui.protocol.Transaction
+import xyz.mcxross.ksui.ptb.ProgrammableTransaction
 
 /**
  * Transaction API implementation
@@ -30,6 +38,37 @@ import xyz.mcxross.ksui.protocol.Transaction
  * @property config The SuiConfig to use
  */
 class Transaction(val config: SuiConfig) : Transaction {
+
+  /**
+   * Execute a transaction block
+   *
+   * This function will execute a transaction block with the given transaction bytes and signatures.
+   *
+   * @param txnBytes The transaction bytes
+   * @param signatures The signatures
+   * @param option The options to use for response
+   * @return An [Option] of nullable [ExecuteTransactionBlock.Result]
+   */
+  override suspend fun executeTransactionBlock(
+    txnBytes: String,
+    signatures: List<String>,
+    option: ExecuteTransactionBlockResponseOptions,
+  ): Option.Some<ExecuteTransactionBlock.Result?> =
+    executeTransactionBlock(config, txnBytes, signatures, option)
+
+  /**
+   * Dry run a transaction block
+   *
+   * This function will dry run a transaction block with the given transaction bytes.
+   *
+   * @param txnBytes The transaction bytes
+   * @param option The options to use for response
+   * @return An [Option] of nullable [DryRunTransactionBlock.Result]
+   */
+  override suspend fun dryRunTransactionBlock(
+    txnBytes: String,
+    option: ExecuteTransactionBlockResponseOptions,
+  ): Option.Some<DryRunTransactionBlock.Result?> = dryRunTransactionBlock(config, txnBytes, option)
 
   /**
    * Get the total transaction blocks
@@ -46,7 +85,37 @@ class Transaction(val config: SuiConfig) : Transaction {
    * @return An [Option] of nullable [TransactionBlocks]
    */
   override suspend fun queryTransactionBlocks(
-    txnBlocksOptions: TransactionBlocksOptions
+    txnBlocksOptions: TransactionBlockResponseOptions
   ): Option<TransactionBlocks> =
     xyz.mcxross.ksui.internal.queryTransactionBlocks(config, txnBlocksOptions)
+
+  /**
+   * Sign a transaction
+   *
+   * This function will sign a transaction with the given message and signer.
+   *
+   * @param message The message
+   * @param signer The signer
+   * @return The signed transaction
+   */
+  override fun signTransaction(message: ByteArray, signer: Account): ByteArray =
+    xyz.mcxross.ksui.internal.signTransaction(message, signer)
+
+  /**
+   * Sign and execute a transaction block
+   *
+   * This function will sign and execute a transaction block with the given programmable transaction
+   * and signer.
+   *
+   * @param ptb The programmable transaction
+   * @param signer The signer
+   * @param gasBudget The gas budget
+   * @return An [Option] of nullable [ExecuteTransactionBlock.Result]
+   */
+  override suspend fun signAndExecuteTransactionBlock(
+    ptb: ProgrammableTransaction,
+    signer: Account,
+    gasBudget: ULong,
+  ): Option.Some<ExecuteTransactionBlock.Result?> =
+    signAndSubmitTransaction(config, ptb, signer, gasBudget)
 }

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/Ed25519.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/Ed25519.kt
@@ -53,9 +53,13 @@ class Ed25519PrivateKey(private val privateKey: ByteArray) : PrivateKey {
    * @throws IllegalArgumentException If the private key is invalid.
    */
   constructor(privateKey: String) : this(PrivateKey.fromEncoded(privateKey).data)
+
+  override fun sign(data: ByteArray): ByteArray {
+    return sign(data, this)
+  }
 }
 
-class Ed25519PublicKey(val data: ByteArray) : PublicKey {
+class Ed25519PublicKey(override val data: ByteArray) : PublicKey {
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.kt
@@ -31,6 +31,8 @@ expect fun importFromMnemonic(mnemonic: String): KeyPair
 
 expect fun importFromMnemonic(mnemonic: List<String>): KeyPair
 
+expect fun sign(message: ByteArray, privateKey: PrivateKey): ByteArray
+
 fun generatePrivateKey(scheme: SignatureScheme): ByteArray {
   return when (scheme) {
     SignatureScheme.ED25519 -> {

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/PrivateKey.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/PrivateKey.kt
@@ -58,6 +58,8 @@ interface PrivateKey {
     )
   }
 
+  fun sign(data: ByteArray): ByteArray
+
   companion object {
 
     /**

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/PublicKey.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/core/crypto/PublicKey.kt
@@ -15,4 +15,6 @@
  */
 package xyz.mcxross.ksui.core.crypto
 
-interface PublicKey
+interface PublicKey {
+  val data: ByteArray
+}

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/internal/Object.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/internal/Object.kt
@@ -84,7 +84,6 @@ internal suspend fun getOwnedObjects(
             showBcs = option.showBcs,
             showContent = option.showContent,
             showDisplay = option.showDisplay,
-            showType = option.showType,
             showOwner = option.showOwner,
             showPreviousTransaction = option.showPreviousTransaction,
             showStorageRebate = option.showStorageRebate,

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/internal/Transaction.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/internal/Transaction.kt
@@ -15,14 +15,74 @@
  */
 package xyz.mcxross.ksui.internal
 
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import xyz.mcxross.bcs.Bcs
+import xyz.mcxross.ksui.account.Account
 import xyz.mcxross.ksui.client.getGraphqlClient
+import xyz.mcxross.ksui.core.crypto.Hash
+import xyz.mcxross.ksui.core.crypto.hash
 import xyz.mcxross.ksui.exception.SuiException
+import xyz.mcxross.ksui.generated.DryRunTransactionBlock
+import xyz.mcxross.ksui.generated.ExecuteTransactionBlock
 import xyz.mcxross.ksui.generated.GetTotalTransactionBlocks
 import xyz.mcxross.ksui.generated.QueryTransactionBlocks
+import xyz.mcxross.ksui.model.AccountAddress
+import xyz.mcxross.ksui.model.Digest
+import xyz.mcxross.ksui.model.ExecuteTransactionBlockResponseOptions
+import xyz.mcxross.ksui.model.Intent
+import xyz.mcxross.ksui.model.IntentMessage
+import xyz.mcxross.ksui.model.ObjectDigest
+import xyz.mcxross.ksui.model.ObjectReference
 import xyz.mcxross.ksui.model.Option
+import xyz.mcxross.ksui.model.Reference
+import xyz.mcxross.ksui.model.SuiAddress
 import xyz.mcxross.ksui.model.SuiConfig
+import xyz.mcxross.ksui.model.TransactionBlockResponseOptions
 import xyz.mcxross.ksui.model.TransactionBlocks
-import xyz.mcxross.ksui.model.TransactionBlocksOptions
+import xyz.mcxross.ksui.model.TransactionDataComposer
+import xyz.mcxross.ksui.model.content
+import xyz.mcxross.ksui.model.with
+import xyz.mcxross.ksui.ptb.ProgrammableTransaction
+
+suspend fun executeTransactionBlock(
+  config: SuiConfig,
+  txnBytes: String,
+  signatures: List<String>,
+  option: ExecuteTransactionBlockResponseOptions,
+): Option.Some<ExecuteTransactionBlock.Result?> {
+  val response =
+    getGraphqlClient(config)
+      .execute<ExecuteTransactionBlock.Result>(
+        ExecuteTransactionBlock(
+          ExecuteTransactionBlock.Variables(txBytes = txnBytes, signatures = signatures)
+        )
+      )
+
+  if (response.errors != null) {
+    throw SuiException(response.errors.toString())
+  }
+
+  return Option.Some(response.data)
+}
+
+internal suspend fun dryRunTransactionBlock(
+  config: SuiConfig,
+  txnBytes: String,
+  option: ExecuteTransactionBlockResponseOptions,
+): Option.Some<DryRunTransactionBlock.Result?> {
+  val response =
+    getGraphqlClient(config)
+      .execute<DryRunTransactionBlock.Result>(
+        DryRunTransactionBlock(DryRunTransactionBlock.Variables(txBytes = txnBytes))
+      )
+
+  if (response.errors != null) {
+    throw SuiException(response.errors.toString())
+  }
+
+  return Option.Some(response.data)
+}
 
 suspend fun getTotalTransactionBlocks(config: SuiConfig): Option<Long?> {
 
@@ -42,25 +102,25 @@ suspend fun getTotalTransactionBlocks(config: SuiConfig): Option<Long?> {
 
 suspend fun queryTransactionBlocks(
   config: SuiConfig,
-  transactionBlocksOptions: TransactionBlocksOptions,
+  transactionBlockResponseOptions: TransactionBlockResponseOptions,
 ): Option<TransactionBlocks> {
   val response =
     getGraphqlClient(config)
       .execute<QueryTransactionBlocks.Result>(
         QueryTransactionBlocks(
           QueryTransactionBlocks.Variables(
-            first = transactionBlocksOptions.first,
-            last = transactionBlocksOptions.last,
-            before = transactionBlocksOptions.before,
-            after = transactionBlocksOptions.after,
-            showBalanceChanges = transactionBlocksOptions.showBalanceChanges,
-            showEffects = transactionBlocksOptions.showEffects,
-            showRawEffects = transactionBlocksOptions.showRawEffects,
-            showEvents = transactionBlocksOptions.showEvents,
-            showInput = transactionBlocksOptions.showInput,
-            showObjectChanges = transactionBlocksOptions.showObjectChanges,
-            showRawInput = transactionBlocksOptions.showRawInput,
-            filter = transactionBlocksOptions.filter,
+            first = transactionBlockResponseOptions.first,
+            last = transactionBlockResponseOptions.last,
+            before = transactionBlockResponseOptions.before,
+            after = transactionBlockResponseOptions.after,
+            showBalanceChanges = transactionBlockResponseOptions.showBalanceChanges,
+            showEffects = transactionBlockResponseOptions.showEffects,
+            showRawEffects = transactionBlockResponseOptions.showRawEffects,
+            showEvents = transactionBlockResponseOptions.showEvents,
+            showInput = transactionBlockResponseOptions.showInput,
+            showObjectChanges = transactionBlockResponseOptions.showObjectChanges,
+            showRawInput = transactionBlockResponseOptions.showRawInput,
+            filter = transactionBlockResponseOptions.filter,
           )
         )
       )
@@ -71,6 +131,78 @@ suspend fun queryTransactionBlocks(
 
   if (response.data == null) {
     return Option.None
+  }
+
+  return Option.Some(response.data)
+}
+
+internal fun signTransaction(message: ByteArray, signer: Account): ByteArray {
+  return signer.sign(message)
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+internal suspend fun signAndSubmitTransaction(
+  config: SuiConfig,
+  ptb: ProgrammableTransaction,
+  signer: Account,
+  gasBudget: ULong,
+): Option.Some<ExecuteTransactionBlock.Result?> {
+
+  val gasPrice =
+    when (val gp = getReferenceGasPrice(config)) {
+      is Option.Some -> gp.value
+      is Option.None -> throw SuiException("Failed to get gas price")
+    }
+
+  val paymentObject =
+    when (val po = getCoins(config, SuiAddress.fromString(signer.address.toString()))) {
+      is Option.Some -> po.value
+      is Option.None -> throw SuiException("Failed to get payment object")
+    }
+
+  val sightedCoin = paymentObject?.address?.coins?.nodes?.get(0)
+
+  val address = sightedCoin?.address ?: throw SuiException("Failed to get address")
+
+  val digest =
+    ObjectDigest(Digest(sightedCoin.digest ?: throw SuiException("Failed to get digest")))
+
+  val txData =
+    TransactionDataComposer.programmable(
+      sender = SuiAddress.fromString(signer.address.toString()),
+      gapPayment =
+        listOf(
+          ObjectReference(
+            Reference(AccountAddress.fromString(address)),
+            sightedCoin.version.toLong(),
+            digest,
+          )
+        ),
+      pt = ptb,
+      gasBudget = gasBudget,
+      gasPrice = gasPrice?.toULong() ?: throw SuiException("Failed to get gas price"),
+    )
+
+  val intentMessage = IntentMessage(Intent.suiTransaction(), txData)
+
+  val sig = signer.sign(hash(Hash.BLAKE2B256, Bcs.encodeToByteArray(intentMessage)))
+
+  val serializedSignatureBytes = byteArrayOf(signer.scheme.scheme) + sig + signer.publicKey.data
+
+  val tx = txData with listOf(Base64.encode(serializedSignatureBytes))
+
+  val content = tx.content()
+
+  val response =
+    getGraphqlClient(config)
+      .execute<ExecuteTransactionBlock.Result>(
+        ExecuteTransactionBlock(
+          ExecuteTransactionBlock.Variables(txBytes = content.first, signatures = content.second)
+        )
+      )
+
+  if (response.errors != null) {
+    throw SuiException(response.errors.toString())
   }
 
   return Option.Some(response.data)

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/Object.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/Object.kt
@@ -18,7 +18,7 @@ package xyz.mcxross.ksui.model
 import kotlinx.serialization.Serializable
 import xyz.mcxross.ksui.util.decodeBase58
 
-@Serializable data class ObjectId(val hash: String)
+@Serializable data class ObjectId(val hash: AccountAddress)
 
 @Serializable
 data class ObjectReference(val reference: Reference, val version: Long, val digest: ObjectDigest)

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/ObjectDataOptions.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/ObjectDataOptions.kt
@@ -29,11 +29,11 @@ package xyz.mcxross.ksui.model
  * @property showStorageRebate Show the storage rebate
  */
 data class ObjectDataOptions(
-  val showBcs: Boolean? = null,
-  val showContent: Boolean? = null,
-  val showDisplay: Boolean? = null,
-  val showType: Boolean? = null,
-  val showOwner: Boolean? = null,
-  val showPreviousTransaction: Boolean? = null,
-  val showStorageRebate: Boolean? = null,
+  val showBcs: Boolean = true,
+  val showContent: Boolean = true,
+  val showDisplay: Boolean = true,
+  val showType: Boolean = true,
+  val showOwner: Boolean = false,
+  val showPreviousTransaction: Boolean = true,
+  val showStorageRebate: Boolean = true,
 )

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/Transaction.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/Transaction.kt
@@ -128,12 +128,12 @@ object TransactionDataComposer {
     sponsor: SuiAddress,
   ): TransactionData =
     withGasCoinsAllowSponsor(
-      TransactionKind.ProgrammableTransaction(pt),
-      sender,
-      gapPayment,
-      gasBudget,
-      gasPrice,
-      sponsor,
+      kind = TransactionKind.ProgrammableTransaction(pt),
+      sender = sender,
+      gapPayment = gapPayment,
+      gasBudget = gasBudget,
+      gasPrice = gasPrice,
+      sponsor = sponsor,
     )
 
   fun withGasCoinsAllowSponsor(
@@ -146,10 +146,10 @@ object TransactionDataComposer {
   ): TransactionData =
     TransactionData.V1(
       TransactionDataV1(
-        kind,
-        sender,
-        GasData(gapPayment, sponsor, gasBudget, gasPrice),
-        TransactionExpiration.None,
+        kind = kind,
+        sender = sender,
+        gasData = GasData(payment = gapPayment, owner = sponsor, price = gasPrice, budget = gasBudget),
+        expiration = TransactionExpiration.None,
       )
     )
 }
@@ -199,10 +199,10 @@ sealed class TransactionData {
     ): TransactionData =
       (TransactionData::V1)(
         TransactionDataV1(
-          kind,
-          sender,
-          GasData(gasPayment, gasSponsor, gasPrice, gasBudget),
-          TransactionExpiration.None,
+          kind = kind,
+          sender = sender,
+          gasData = GasData(gasPayment, gasSponsor, gasPrice, gasBudget),
+          expiration = TransactionExpiration.None,
         )
       )
   }
@@ -213,8 +213,15 @@ sealed class TransactionData {
   }
 }
 
+// TODO: This is a placeholder for now, look back at this later
+
+enum class B{
+  A
+}
+
 @Serializable
 data class TransactionDataV1(
+  val a : B = B.A,
   val kind: TransactionKind,
   val sender: SuiAddress,
   val gasData: GasData,
@@ -250,7 +257,7 @@ fun TransactionData.toTransaction(txSignatures: List<String>): Txn =
 
 infix fun TransactionData.with(txSignatures: List<String>): Txn = toTransaction(txSignatures)
 
-@OptIn(ExperimentalEncodingApi::class) fun Txn.data(): String = Base64.encode(bcsEncode(this.data))
+@OptIn(ExperimentalEncodingApi::class) fun Txn.data(): String = Base64.encode(bcsEncode(this.data.senderSignedTransactions[0].intentMessage.value))
 
 fun Txn.signatures(): List<String> = this.data.senderSignedTransactions.first().txSignatures
 

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/TransactionBlockResponseOptions.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/model/TransactionBlockResponseOptions.kt
@@ -17,7 +17,7 @@ import xyz.mcxross.ksui.generated.inputs.TransactionBlockFilter
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-data class TransactionBlocksOptions(
+data class TransactionBlockResponseOptions(
   val first: Int? = null,
   val last: Int? = null,
   val before: String? = null,
@@ -30,4 +30,14 @@ data class TransactionBlocksOptions(
   val showObjectChanges: Boolean? = null,
   val showRawInput: Boolean? = null,
   val filter: TransactionBlockFilter? = null,
+)
+
+data class ExecuteTransactionBlockResponseOptions(
+  val showBalanceChanges: Boolean = false,
+  val showEffects: Boolean = false,
+  val showRawEffects: Boolean = false,
+  val showEvents: Boolean = false,
+  val showInput: Boolean = false,
+  val showObjectChanges: Boolean = false,
+  val showRawInput: Boolean = false,
 )

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/protocol/Transaction.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/protocol/Transaction.kt
@@ -15,9 +15,14 @@
  */
 package xyz.mcxross.ksui.protocol
 
+import xyz.mcxross.ksui.account.Account
+import xyz.mcxross.ksui.generated.DryRunTransactionBlock
+import xyz.mcxross.ksui.generated.ExecuteTransactionBlock
+import xyz.mcxross.ksui.model.ExecuteTransactionBlockResponseOptions
 import xyz.mcxross.ksui.model.Option
+import xyz.mcxross.ksui.model.TransactionBlockResponseOptions
 import xyz.mcxross.ksui.model.TransactionBlocks
-import xyz.mcxross.ksui.model.TransactionBlocksOptions
+import xyz.mcxross.ksui.ptb.ProgrammableTransaction
 
 /**
  * Transaction interface
@@ -25,6 +30,36 @@ import xyz.mcxross.ksui.model.TransactionBlocksOptions
  * This interface represents the transaction API
  */
 interface Transaction {
+
+  /**
+   * Execute a transaction block
+   *
+   * This function will execute a transaction block with the given transaction bytes and signatures.
+   *
+   * @param txnBytes The transaction bytes
+   * @param signatures The signatures
+   * @param option The options to use for response
+   * @return An [Option] of nullable [ExecuteTransactionBlock.Result]
+   */
+  suspend fun executeTransactionBlock(
+    txnBytes: String,
+    signatures: List<String>,
+    option: ExecuteTransactionBlockResponseOptions = ExecuteTransactionBlockResponseOptions(),
+  ): Option.Some<ExecuteTransactionBlock.Result?>
+
+  /**
+   * Dry run a transaction block
+   *
+   * This function will dry run a transaction block with the given transaction bytes.
+   *
+   * @param txnBytes The transaction bytes
+   * @param option The options to use for response
+   * @return An [Option] of nullable [DryRunTransactionBlock.Result]
+   */
+  suspend fun dryRunTransactionBlock(
+    txnBytes: String,
+    option: ExecuteTransactionBlockResponseOptions = ExecuteTransactionBlockResponseOptions(),
+  ): Option.Some<DryRunTransactionBlock.Result?>
 
   /**
    * Get the total transaction blocks
@@ -40,6 +75,34 @@ interface Transaction {
    * @return An [Option] of nullable [TransactionBlocks]
    */
   suspend fun queryTransactionBlocks(
-    txnBlocksOptions: TransactionBlocksOptions = TransactionBlocksOptions()
+    txnBlocksOptions: TransactionBlockResponseOptions = TransactionBlockResponseOptions()
   ): Option<TransactionBlocks>
+
+  /**
+   * Sign a transaction
+   *
+   * This function will sign a transaction with the given message and signer.
+   *
+   * @param message The message to sign
+   * @param signer The signer
+   * @return The signed transaction
+   */
+  fun signTransaction(message: ByteArray, signer: Account): ByteArray
+
+  /**
+   * Sign and execute a transaction block
+   *
+   * This function will sign and execute a transaction block with the given programmable transaction
+   * and signer.
+   *
+   * @param ptb The programmable transaction
+   * @param signer The signer
+   * @param gasBudget The gas budget
+   * @return An [Option] of nullable [ExecuteTransactionBlock.Result]
+   */
+  suspend fun signAndExecuteTransactionBlock(
+    ptb: ProgrammableTransaction,
+    signer: Account,
+    gasBudget: ULong = 5_000_000UL,
+  ): Option.Some<ExecuteTransactionBlock.Result?>
 }

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/serializer/TransactionFilterSerializer.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/serializer/TransactionFilterSerializer.kt
@@ -38,15 +38,17 @@ object TransactionFilterSerializer : KSerializer<TransactionFilter> {
         is TransactionFilter.MoveFunction ->
           buildJsonObject {
             putJsonObject("MoveFunction") {
-              put("package", value.pakage.hash)
+              //put("package", value.pakage.hash)
               put("module", value.module)
               put("function", value.function)
             }
           }
         is TransactionFilter.InputObject ->
-          buildJsonObject { put("InputObject", value.objectId.hash) }
+          throw Exception("TransactionFilterSerializer: InputObject is not supported")
+          //buildJsonObject { put("InputObject", value.objectId.hash) }
         is TransactionFilter.ChangedObject ->
-          buildJsonObject { put("ChangedObject", value.objectId.hash) }
+          throw Exception("TransactionFilterSerializer: ChangedObject is not supported")
+          //buildJsonObject { put("ChangedObject", value.objectId.hash) }
         is TransactionFilter.FromAddress ->
           buildJsonObject { put("FromAddress", value.address.toString()) }
         is TransactionFilter.ToAddress ->

--- a/lib/src/commonMain/kotlin/xyz/mcxross/ksui/serializer/V1Serializer.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/ksui/serializer/V1Serializer.kt
@@ -25,7 +25,7 @@ object V1Serializer : kotlinx.serialization.KSerializer<TransactionData> {
   override fun serialize(encoder: kotlinx.serialization.encoding.Encoder, value: TransactionData) {
     when (value) {
       is TransactionData.V1 -> {
-        encoder.encodeEnum(descriptor, 0)
+        //encoder.encodeEnum(TransactionData.V1.serializer().descriptor)
         encoder.beginStructure(descriptor).apply {
           encodeSerializableElement(descriptor, 0, serializer(), value)
           endStructure(descriptor)

--- a/lib/src/commonMain/resources/dryRunTransactionBlock.graphql
+++ b/lib/src/commonMain/resources/dryRunTransactionBlock.graphql
@@ -1,0 +1,95 @@
+query dryRunTransactionBlock(
+    $txBytes: String!
+    $showBalanceChanges: Boolean = false
+    $showEffects: Boolean = false
+    $showEvents: Boolean = false
+    $showObjectChanges: Boolean = false
+    $showRawInput: Boolean = false
+) {
+    dryRunTransactionBlock(txBytes: $txBytes) {
+        error
+        transaction {
+            ...RPC_TRANSACTION_FIELDS
+        }
+    }
+}
+
+fragment RPC_TRANSACTION_FIELDS on TransactionBlock {
+    digest
+    rawTransaction: bcs @include(if: $showRawInput)
+    sender {
+        address
+    }
+
+    signatures
+
+    effects {
+        bcs @include(if: $showEffects)
+        events @include(if: $showEvents) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+        }
+        checkpoint {
+            sequenceNumber
+        }
+        timestamp
+        balanceChanges @include(if: $showBalanceChanges) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+            nodes {
+                coinType {
+                    repr
+                }
+                owner {
+                    asObject {
+                        address
+                    }
+                    asAddress {
+                        address
+                    }
+                }
+                amount
+            }
+        }
+
+        objectChanges @include(if: $showObjectChanges) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+            nodes {
+                address
+                inputState {
+                    version
+                    asMoveObject {
+                        contents {
+                            type {
+                                repr
+                            }
+                        }
+                    }
+                }
+                outputState {
+                    asMoveObject {
+                        contents {
+                            type {
+                                repr
+                            }
+                        }
+                    }
+                    asMovePackage {
+                        modules(first: 10) {
+                            nodes {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/src/commonMain/resources/executeTransactionBlock.graphql
+++ b/lib/src/commonMain/resources/executeTransactionBlock.graphql
@@ -1,0 +1,26 @@
+mutation executeTransactionBlock(
+    $txBytes: String!
+    $signatures: [String!]!
+) {
+    executeTransactionBlock(txBytes: $txBytes, signatures: $signatures) {
+        errors
+        effects {
+            transactionBlock {
+                digest
+
+                sender {
+                    address
+                }
+
+                signatures
+
+                effects {
+                    checkpoint {
+                        sequenceNumber
+                    }
+                    timestamp
+                }
+            }
+        }
+    }
+}

--- a/lib/src/commonMain/resources/getOwnedObjects.graphql
+++ b/lib/src/commonMain/resources/getOwnedObjects.graphql
@@ -5,7 +5,6 @@ query getOwnedObjects(
 	$showBcs: Boolean = false
 	$showContent: Boolean = false
 	$showDisplay: Boolean = false
-	$showType: Boolean = false
 	$showOwner: Boolean = false
 	$showPreviousTransaction: Boolean = false
 	$showStorageRebate: Boolean = false

--- a/lib/src/jsMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.js.kt
+++ b/lib/src/jsMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.js.kt
@@ -42,3 +42,10 @@ actual fun importFromMnemonic(mnemonic: String): KeyPair {
 actual fun importFromMnemonic(mnemonic: List<String>): KeyPair {
   TODO("Not yet implemented")
 }
+
+actual fun sign(
+  message: ByteArray,
+  privateKey: PrivateKey
+): ByteArray {
+  TODO("Not yet implemented")
+}

--- a/lib/src/linuxMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.linux.kt
+++ b/lib/src/linuxMain/kotlin/xyz/mcxross/ksui/core/crypto/Platform.linux.kt
@@ -45,3 +45,10 @@ actual fun importFromMnemonic(mnemonic: String): KeyPair {
 actual fun importFromMnemonic(mnemonic: List<String>): KeyPair {
   TODO("Not yet implemented")
 }
+
+actual fun sign(
+  message: ByteArray,
+  privateKey: PrivateKey
+): ByteArray {
+  TODO("Not yet implemented")
+}


### PR DESCRIPTION
- Added support for executing txns on-chain.
- Added txn simulation using the `dryRunTransactionBlock` function to validate txns without committing them to the blockchain.
- Implemented txn signing to authorize and securely submit txns.
- Got programmable txn construction working. `SplitCoins`, `MoveCall` and `TransferObjects` commands working.